### PR TITLE
[DM-15396] Stack based container builds

### DIFF
--- a/docker/build_stackbase.sh
+++ b/docker/build_stackbase.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+docker build -t webserv/stackbase stackbase

--- a/docker/build_stackbase.sh
+++ b/docker/build_stackbase.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker build -t webserv/stackbase stackbase
+docker build --no-cache -t webserv/stackbase stackbase

--- a/docker/stackbase/Dockerfile
+++ b/docker/stackbase/Dockerfile
@@ -1,0 +1,13 @@
+FROM lsstsqre/centos:7-stack-lsst_distrib-w_2018_33
+MAINTAINER Christine Banek <cbanek@lsst.org>
+
+COPY bake.sh /home/lsst/bake.sh
+RUN /home/lsst/bake.sh
+
+# Bring in ENTRYPOINT
+COPY webserv/entrypoint.sh /webserv/entrypoint.sh
+
+# Switch to root so we can start nginx,
+# entrypoint does a `su webserv` internally to start wsgi as
+# as webserv
+ENTRYPOINT /webserv/entrypoint.sh

--- a/docker/stackbase/Dockerfile
+++ b/docker/stackbase/Dockerfile
@@ -1,3 +1,4 @@
+#TODO(DM-15620): Have this follow the latest stack image.
 FROM lsstsqre/centos:7-stack-lsst_distrib-w_2018_33
 MAINTAINER Christine Banek <cbanek@lsst.org>
 

--- a/docker/stackbase/Dockerfile
+++ b/docker/stackbase/Dockerfile
@@ -1,8 +1,11 @@
 FROM lsstsqre/centos:7-stack-lsst_distrib-w_2018_33
 MAINTAINER Christine Banek <cbanek@lsst.org>
 
-COPY bake.sh /home/lsst/bake.sh
-RUN /home/lsst/bake.sh
+USER root
+
+# Configure nginx
+COPY etc/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY etc/nginx/sites-enabled/webserv /etc/nginx/sites-enabled/webserv
 
 # Bring in ENTRYPOINT
 COPY webserv/entrypoint.sh /webserv/entrypoint.sh
@@ -11,3 +14,7 @@ COPY webserv/entrypoint.sh /webserv/entrypoint.sh
 # entrypoint does a `su webserv` internally to start wsgi as
 # as webserv
 ENTRYPOINT /webserv/entrypoint.sh
+
+# Install packages and run additional commands.
+COPY bake.sh /root/bake.sh
+RUN /root/bake.sh

--- a/docker/stackbase/bake.sh
+++ b/docker/stackbase/bake.sh
@@ -11,17 +11,17 @@ source /opt/lsst/software/stack/loadLSST.bash
 setup lsst_distrib
 
 cd ~
-git clone https://github.com/lsst/dax_webservcommon.git -b tickets/DM-15396
+git clone https://github.com/lsst/dax_webservcommon.git -b master
 (cd dax_webservcommon && pip install -r requirements.txt && pip install . && python setup.py test)
 
-git clone https://github.com/lsst/dax_metaserv.git -b tickets/DM-15396
+git clone https://github.com/lsst/dax_metaserv.git -b master
 (cd dax_metaserv && pip install -r requirements.txt && pip install . && python setup.py test)
 
-git clone https://github.com/lsst/dax_dbserv.git -b tickets/DM-15396
+git clone https://github.com/lsst/dax_dbserv.git -b master
 (cd dax_dbserv && pip install -r requirements.txt && pip install . && python setup.py test)
 
-git clone https://github.com/lsst/dax_imgserv.git -b tickets/DM-15396
-# TODO: Still need to fix test.
+git clone https://github.com/lsst/dax_imgserv.git -b master
+# TODO(DM-15694): Still need to fix imgserv test.
 #(cd dax_imgserv && pip install -r requirements.txt && pip install . && python setup.py test)
 (cd dax_imgserv && pip install -r requirements.txt && pip install .)
 

--- a/docker/stackbase/bake.sh
+++ b/docker/stackbase/bake.sh
@@ -1,11 +1,29 @@
 #!/bin/bash -ex
+# We need this to get mysql_config, which is required to
+# install the mysqlclient python package which dbserv
+# depends on.
+yum install -y mysql-devel nginx
+
+chown -R lsst:lsst /webserv
+chown -R lsst:lsst /var/lib/nginx
+
 source /opt/lsst/software/stack/loadLSST.bash
+setup lsst_distrib
 
 cd ~
-git clone https://github.com/lsst/dax_dbserv.git
-git clone https://github.com/lsst/dax_metaserv.git
-git clone https://github.com/lsst/dax_imgserv.git
-git clone https://github.com/lsst/dax_webserv.git
 git clone https://github.com/lsst/dax_webservcommon.git -b tickets/DM-15396
+(cd dax_webservcommon && pip install -r requirements.txt && pip install . && python setup.py test)
 
-(cd dax_webservcommon && python setup.py install)
+git clone https://github.com/lsst/dax_metaserv.git -b tickets/DM-15396
+(cd dax_metaserv && pip install -r requirements.txt && pip install . && python setup.py test)
+
+git clone https://github.com/lsst/dax_dbserv.git -b tickets/DM-15396
+(cd dax_dbserv && pip install -r requirements.txt && pip install . && python setup.py test)
+
+git clone https://github.com/lsst/dax_imgserv.git -b tickets/DM-15396
+# TODO: Still need to fix test.
+#(cd dax_imgserv && pip install -r requirements.txt && pip install . && python setup.py test)
+(cd dax_imgserv && pip install -r requirements.txt && pip install .)
+
+pip install uwsgi
+git clone https://github.com/lsst/dax_webserv.git

--- a/docker/stackbase/bake.sh
+++ b/docker/stackbase/bake.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -ex
+source /opt/lsst/software/stack/loadLSST.bash
+
+cd ~
+git clone https://github.com/lsst/dax_dbserv.git
+git clone https://github.com/lsst/dax_metaserv.git
+git clone https://github.com/lsst/dax_imgserv.git
+git clone https://github.com/lsst/dax_webserv.git
+git clone https://github.com/lsst/dax_webservcommon.git -b tickets/DM-15396
+
+(cd dax_webservcommon && python setup.py install)

--- a/docker/stackbase/etc/nginx/nginx.conf
+++ b/docker/stackbase/etc/nginx/nginx.conf
@@ -1,4 +1,4 @@
-user webserv;
+user lsst;
 worker_processes auto;
 pid /run/nginx.pid;
 

--- a/docker/stackbase/etc/nginx/nginx.conf
+++ b/docker/stackbase/etc/nginx/nginx.conf
@@ -1,0 +1,32 @@
+user webserv;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+    worker_connections 32;
+}
+
+http {
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 1200;
+    types_hash_max_size 2048;
+    send_timeout 7200;
+    client_body_timeout 7200;
+
+    # server_names_hash_bucket_size 64;
+    # server_name_in_redirect off;
+
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    gzip on;
+    gzip_types *;
+
+    include /etc/nginx/conf.d/*.conf;
+    include /etc/nginx/sites-enabled/*;
+}

--- a/docker/stackbase/etc/nginx/sites-enabled/webserv
+++ b/docker/stackbase/etc/nginx/sites-enabled/webserv
@@ -1,0 +1,10 @@
+server {
+    listen 5000 default_server;
+    server_name _;
+
+    location / {
+        include uwsgi_params;
+        uwsgi_read_timeout 7200;
+        uwsgi_pass unix:///tmp/webserv.sock;
+    }
+}

--- a/docker/stackbase/webserv/entrypoint.sh
+++ b/docker/stackbase/webserv/entrypoint.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # Start nginx
+nginx
 
-/etc/init.d/nginx start
-
-# Activacte Stack, setup dax_webserv, and run uwsgi
-su webserv -c'\
-source /lsst/stack/loadLSST.bash; \
-setup dax_webserv; \
+# Activacte Stack, setup dax_webserv, and run
+# uwsgi under the lsst UID.
+source /opt/lsst/software/stack/loadLSST.bash
+setup lsst_distrib
 uwsgi --master --processes 40 --threads 1 \
-    --socket /tmp/webserv.sock \
-    --wsgi-file $DAX_WEBSERV_DIR/bin/server.py --callable app 2> /webserv/log.txt'
+    --socket /tmp/webserv.sock --uid lsst \
+    --callable app --need-app \
+    --wsgi-file /root/dax_webserv/bin/server.py

--- a/docker/stackbase/webserv/entrypoint.sh
+++ b/docker/stackbase/webserv/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Start nginx
+
+/etc/init.d/nginx start
+
+# Activacte Stack, setup dax_webserv, and run uwsgi
+su webserv -c'\
+source /lsst/stack/loadLSST.bash; \
+setup dax_webserv; \
+uwsgi --master --processes 40 --threads 1 \
+    --socket /tmp/webserv.sock \
+    --wsgi-file $DAX_WEBSERV_DIR/bin/server.py --callable app 2> /webserv/log.txt'


### PR DESCRIPTION
Here's a sneak preview of the stack based container builds.

A few changes:
1) Using the weekly stack container that sqre builds.  One small note, this is centos7 instead of ubuntu, so a few things changed.
2) I'm running instructions as root, but telling uwsgi to run as the lsst user, which already exists now in the container as the default stack user.  No need to create a user and chmod things as before.  No need to su run uwsgi.
3) Installs all the python modules using setup.py
4) Change nginx start procedure.  Centos containers don't even have systemctl installed by default, but running nginx will spin up the server and its workers.  It is now also configured to run as lsst.
5) Don't bother redirecting stdout to a file.  Maybe I should tee it, but having the output right there in kubectl logs -f is super useful.

Things left:
1) Imgserv unit tests don't work yet, due to dependency on lsst.db eups package.
2) Don't call out a specific weekly stack image in the dockerfile, but track the latest successful one.