### PR TITLE
Remove imgserv from webserv

### DIFF
--- a/kube/int/dax-webserv-deployment.yaml
+++ b/kube/int/dax-webserv-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: dax-webserv
-        image: webserv/webserv:webserv_latest_3
+        image: webserv/webserv:webserv_latest_soda
         env:
         - name: WEBSERV_CONFIG
           value: "/etc/dax-webserv/webserv.ini"

--- a/kube/int/dax-webserv-ingress.yaml
+++ b/kube/int/dax-webserv-ingress.yaml
@@ -13,8 +13,4 @@ spec:
       - backend:
           serviceName: dax-webserv-service
           servicePort: 5000
-        path: /api/image
-      - backend:
-          serviceName: dax-webserv-service
-          servicePort: 5000
         path: /api/meta/v1

--- a/kube/int/test.sh
+++ b/kube/int/test.sh
@@ -1,8 +1,4 @@
 #!/bin/bash -ex
 
-echo "Image serve tests..."
-
-curl --fail -o /tmp/calexp_i6_out.fits "https://lsst-lsp-int.ncsa.illinois.edu/api/image/v1/DC_W13_Stripe82?ds=calexp&ra=37.644598&dec=0.104625&filter=r"
-
 echo "Meta serve tests..."
 curl --fail -o /tmp/table_metadata.json "https://lsst-lsp-int.ncsa.illinois.edu/api/meta/v1/db/1/1/tables/1/"

--- a/kube/stable/dax-webserv-deployment.yaml
+++ b/kube/stable/dax-webserv-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: dax-webserv
-        image: webserv/webserv:webserv_latest_3
+        image: webserv/webserv:webserv_latest_soda
         env:
         - name: WEBSERV_CONFIG
           value: "/etc/dax-webserv/webserv.ini"

--- a/kube/stable/dax-webserv-ingress.yaml
+++ b/kube/stable/dax-webserv-ingress.yaml
@@ -13,8 +13,4 @@ spec:
       - backend:
           serviceName: dax-webserv-service
           servicePort: 5000
-        path: /api/image
-      - backend:
-          serviceName: dax-webserv-service
-          servicePort: 5000
         path: /api/meta/v1

--- a/kube/stable/test.sh
+++ b/kube/stable/test.sh
@@ -1,8 +1,4 @@
 #!/bin/bash -ex
 
-echo "Image serve tests..."
-
-curl --fail -o /tmp/calexp_i6_out.fits "https://lsst-lsp-stable.ncsa.illinois.edu/api/image/v1/DC_W13_Stripe82?ds=calexp&ra=37.644598&dec=0.104625&filter=r"
-
 echo "Meta serve tests..."
 curl --fail -o /tmp/table_metadata.json "https://lsst-lsp-stable.ncsa.illinois.edu/api/meta/v1/db/1/1/tables/1/"


### PR DESCRIPTION
Changes here to direct /api/image to use new image for imgserv, and remove from webserv accordiningly.